### PR TITLE
Add custom OSC command action

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,8 @@ export interface Options {
 	name: EnforceDefault<CompanionInputFieldTextInput, string>
 	time: EnforceDefault<CompanionInputFieldNumber, number>
 	value: EnforceDefault<CompanionInputFieldNumber, number>
+	oscPath: EnforceDefault<CompanionInputFieldTextInput, string>
+	oscArgs: EnforceDefault<CompanionInputFieldTextInput, string>
 }
 
 export const options: Options = {
@@ -40,6 +42,20 @@ export const options: Options = {
 		default: 0,
 		min: -65535,
 		max: 65535,
+	},
+	oscPath: {
+		type: 'textinput',
+		label: 'OSC Path',
+		id: 'oscPath',
+		default: '/millumin/action/custom',
+		tooltip: 'Enter the OSC path (e.g., /millumin/action/custom)',
+	},
+	oscArgs: {
+		type: 'textinput',
+		label: 'OSC Arguments',
+		id: 'oscArgs',
+		default: '',
+		tooltip: 'Optional: Enter arguments as comma-separated values with type prefix (e.g., i:1,s:hello,f:0.5)',
 	},
 }
 


### PR DESCRIPTION
This PR adds a custom OSC command action to Millumin. This gives the user more flexibility with commands without needing to have both the Millumin and Generic: OSC modules enabled in Companion.

It also bridges any gaps between the interactions panel in Millumin and the API. For example, toggling Silent Edition in Millumin5 isn't part of the API (at least not documented) or the current Companion Module. However, you can send an OSC command and link it to toggling Silent Edition in the Interactions panel.