### PR TITLE
Add media logging options

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "anomes-millumin",
 	"shortname": "millumin",
 	"description": "Millumin plugin for Companion",
-	"version": "3.0.0-0",
+	"version": "5.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-anomes-millumin.git",
 	"bugs": "https://github.com/bitfocus/companion-module-anomes-millumin/issues",
@@ -38,7 +38,8 @@
 	"products": [
 		"Millumin 2",
 		"Millumin 3",
-		"Millumin 4"
+		"Millumin 4",
+		"Millumin 5"
 	],
 	"keywords": [
 		"Software",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "anomes-millumin",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"main": "dist/index.js",
 	"repository": {
 		"type": "git",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ export interface MilluminConfig {
 	rx_port: number
 	timeLayerName: string
 	trackMultipleLayers: boolean
+	logMediaStarts: boolean
+	logMediaStops: boolean
 }
 
 export const getConfigFields = (): SomeCompanionConfigField[] => {
@@ -66,6 +68,27 @@ export const getConfigFields = (): SomeCompanionConfigField[] => {
 			label: 'Enable tracking of multiple layer (comma separated list)',
 			width: 12,
 			default: false,
-		}
+		},
+		{
+			type: 'static-text',
+			width: 12,
+			value: 'Write media playback events to the Companion log. Useful if you need to provide a audit trail of e.g. advert playouts.',
+			id: 'info',
+			label: 'Logging',
+		},
+		{
+			type: 'checkbox',
+			id: 'logMediaStarts',
+			label: 'Log media start events',
+			width: 6,
+			default: false,
+		},
+		{
+			type: 'checkbox',
+			id: 'logMediaStops',
+			label: 'Log media stop events',
+			width: 6,
+			default: false,
+		},
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 import { InstanceBase, runEntrypoint, SomeCompanionConfigField } from '@companion-module/base'
 import { getConfigFields, MilluminConfig } from './config'
 import { getActions } from './actions'
-import {FeedbackId, getFeedbacks} from './feedback'
+import { FeedbackId, getFeedbacks } from './feedback'
 import { GetPresetList } from './presets'
 import { initVariables, updateVariables } from './variables'
 import { OSC, OSCResponse } from './osc'
 import { UpgradeV2ToV3 } from './upgrades'
-import {InstanceBaseExt, MediaLayer} from "./utils";
+import { InstanceBaseExt, MediaLayer } from "./utils";
 
-class MilluminInstance extends InstanceBase<MilluminConfig> implements InstanceBaseExt<MilluminConfig>{
+class MilluminInstance extends InstanceBase<MilluminConfig> implements InstanceBaseExt<MilluminConfig> {
 	public config: MilluminConfig = {
 		label: '',
 		host: '',
@@ -16,6 +16,8 @@ class MilluminInstance extends InstanceBase<MilluminConfig> implements InstanceB
 		rx_port: 0,
 		timeLayerName: '',
 		trackMultipleLayers: false,
+		logMediaStarts: false,
+		logMediaStops: false,
 	}
 
 	public OSC: OSC | null = null
@@ -138,6 +140,16 @@ class MilluminInstance extends InstanceBase<MilluminConfig> implements InstanceB
 			}
 
 			this.updateMediaLayer(data.address, layerName, data.args)
+
+			if (this.config.logMediaStarts && data.address.endsWith('mediaStarted') && 2 <= data.args.length) {
+				let logMessage = `Media started on layer ${layerName}, column #${data.args[0].value}, filename: ${data.args[1].value}`;
+				if (3 <= data.args.length) {
+					logMessage += `, duration: ${data.args[2].value}s`;
+				}
+				this.log('info', logMessage);
+			} else if (this.config.logMediaStops && data.address.endsWith('mediaStopped') && 2 <= data.args.length) {
+				this.log('info', `Media stopped on layer ${layerName}, column #${data.args[0].value}, filename: ${data.args[1].value}`);
+			}
 		}
 	}
 
@@ -156,7 +168,7 @@ class MilluminInstance extends InstanceBase<MilluminConfig> implements InstanceB
 				this.mediaLayers[layerName].elapsedTime = 0
 				this.mediaLayers[layerName].duration = 0
 			}
-		} else if (address.endsWith('/mediaStopped')&&
+		} else if (address.endsWith('/mediaStopped') &&
 			1 <= args.length) {
 			if (this.mediaLayers[layerName].mediaIndex == args[1].value) {
 				this.mediaLayers[layerName].elapsedTime = 0


### PR DESCRIPTION
I often work on live shows where we use Millumin to play out sponsor adverts, and we're required to provide an audit log of the playouts after the event so we can confirm we matched the schedule/frequency of playouts the client has asked for.

In order to make this easier, I've added some simple logging options to the module. It'll record media start and stop events to the Companion log, and this data can later be used to produce a report for the client.

This won't be required in all installs, so the user can toggle this on/off in the config page.

I've set it to disabled by default, but I think there's a good argument to set it to enabled by default (or even always on) - this data may not be required on all jobs but it's probably better to have it and not need it etc. etc.

Removing the config options and just doing this logging by default would also keep the config page a bit cleaner.

Hope this helps! 